### PR TITLE
Top P cannot be higher than 1.0

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -707,8 +707,8 @@ export default function Home() {
   const handleTopPChange = (event) => {
     event.preventDefault();
     setTopP(event.target.value);
-    // The minimum value is 0, and the maximum is 2
-    setTechnicalTopP(event.target.value / 50);
+    // The minimum value is 0, and the maximum is 1
+    setTechnicalTopP(event.target.value / 100);
   };
 
   const handleFrequencyPenaltyChange = (event) => {


### PR DESCRIPTION
Updated the UI cap to reflect the official limits of Top P, as any values beyond 1.0 would result in an error regardless of the backend used.